### PR TITLE
Feat: add websocket inbound channel interceptor

### DIFF
--- a/src/main/kotlin/smalltalk/backend/config/websocket/StompHandler.kt
+++ b/src/main/kotlin/smalltalk/backend/config/websocket/StompHandler.kt
@@ -1,0 +1,41 @@
+package smalltalk.backend.config.websocket
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand.*
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.stereotype.Component
+
+@Component
+class StompHandler (
+    private val webSocketSessionSet: WebSocketSessionSet
+): ChannelInterceptor {
+
+    private val logger = KotlinLogging.logger {}
+
+    override fun preSend(message: Message<*>, channel: MessageChannel): Message<*>? =
+        message.also {
+            val header = StompHeaderAccessor.wrap(it)
+            when (header.command) {
+                CONNECT -> handleConnect(header.sessionId)
+                DISCONNECT -> handleDisconnect(header.sessionId)
+                else -> logger.info { "not yet be implemented command handling" }
+            }
+        }
+
+    override fun postSend(message: Message<*>, channel: MessageChannel, sent: Boolean) {
+        if (!sent) logger.info { "sent failed" }
+    }
+
+    private fun handleConnect(sessionId: String?) {
+        sessionId?.let { webSocketSessionSet.addSession(sessionId) }
+        logger.info { "save new session $sessionId" }
+    }
+
+    private fun handleDisconnect(sessionId: String?) {
+        sessionId?.let { webSocketSessionSet.removeSession(sessionId) }
+        logger.info { "remove session $sessionId" }
+    }
+}

--- a/src/main/kotlin/smalltalk/backend/config/websocket/WebSocketConfig.kt
+++ b/src/main/kotlin/smalltalk/backend/config/websocket/WebSocketConfig.kt
@@ -1,15 +1,21 @@
 package smalltalk.backend.config.websocket
 
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.client.standard.StandardWebSocketClient
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+import org.springframework.web.socket.messaging.WebSocketStompClient
 
 
 @Configuration
 @EnableWebSocketMessageBroker
-class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+class WebSocketConfig (
+    private val stompHandler: StompHandler
+): WebSocketMessageBrokerConfigurer {
 
     override fun configureMessageBroker(config: MessageBrokerRegistry) {
         // /rooms/something 주소를 구독하는 클라이언트에게 메시지를 보낼 수 있게 브로커 활성화
@@ -23,4 +29,14 @@ class WebSocketConfig : WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws-connect").setAllowedOrigins("*")
         registry.addEndpoint("/ws-connect").setAllowedOrigins("*").withSockJS()
     }
+
+    // 메시지가 클라이언트로부터 들어올 때 호출
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        registration.interceptors(stompHandler)
+    }
+
+    @Bean
+    fun webSocketClient() : WebSocketStompClient =
+        WebSocketStompClient(StandardWebSocketClient())
 }
+

--- a/src/main/kotlin/smalltalk/backend/config/websocket/WebSocketSessionSet.kt
+++ b/src/main/kotlin/smalltalk/backend/config/websocket/WebSocketSessionSet.kt
@@ -1,0 +1,15 @@
+package smalltalk.backend.config.websocket
+
+import org.springframework.stereotype.Component
+
+@Component
+class WebSocketSessionSet {
+
+    private final val sessionSet: MutableSet<String> = linkedSetOf()
+
+    fun addSession(sessionId: String) = sessionSet.add(sessionId)
+
+    fun removeSession(sessionId: String) = sessionSet.remove(sessionId)
+
+    fun getSessionNum() = sessionSet.size
+}

--- a/src/main/kotlin/smalltalk/backend/config/websocket/WebSocketSessionSet.kt
+++ b/src/main/kotlin/smalltalk/backend/config/websocket/WebSocketSessionSet.kt
@@ -5,11 +5,12 @@ import org.springframework.stereotype.Component
 @Component
 class WebSocketSessionSet {
 
-    private final val sessionSet: MutableSet<String> = linkedSetOf()
+    private val sessionSet: MutableSet<String> = linkedSetOf()
 
     fun addSession(sessionId: String) = sessionSet.add(sessionId)
 
     fun removeSession(sessionId: String) = sessionSet.remove(sessionId)
 
     fun getSessionNum() = sessionSet.size
+
 }


### PR DESCRIPTION
## Summary
- Websocket Channel Interceptor 로 StompHandler 를 추가하였습니다.

## Related Issue
- close #9 

## Etc
- Websocket Client 빈이 선언되어 있는데, 지금은 신경쓰지 말아주세요 공부를 더 한 다음에 사용해볼 예정입니다.
- preSend() 는 클라이언트가 보낸 메시지가 채널로 도착하기 전, postSend() 는 채널로 도착한 후에 각각 호출됩니다.