### PR TITLE
[ #23 ] feat: send receipt message by subscribe event

### DIFF
--- a/src/main/kotlin/smalltalk/backend/config/websocket/OutboundChannelInterceptor.kt
+++ b/src/main/kotlin/smalltalk/backend/config/websocket/OutboundChannelInterceptor.kt
@@ -3,6 +3,9 @@ package smalltalk.backend.config.websocket
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.messaging.Message
 import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.SimpMessageType
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.messaging.support.ChannelInterceptor
 import org.springframework.stereotype.Component
 
@@ -10,8 +13,16 @@ import org.springframework.stereotype.Component
 class OutboundChannelInterceptor: ChannelInterceptor {
 
     private val logger = KotlinLogging.logger {}
+    companion object {
+        private const val SIMP_MESSAGE_TYPE_KEY = "simpMessageType"
+    }
 
     override fun preSend(message: Message<*>, channel: MessageChannel): Message<*>? {
+        if (StompHeaderAccessor.wrap(message).command == StompCommand.RECEIPT)
+            logger.info { "Receipt $message" }
+        if (message.headers[SIMP_MESSAGE_TYPE_KEY] == SimpMessageType.MESSAGE) {
+            logger.info { "Message $message" }
+        }
         return message
     }
 }

--- a/src/main/kotlin/smalltalk/backend/config/websocket/WebSocketConfig.kt
+++ b/src/main/kotlin/smalltalk/backend/config/websocket/WebSocketConfig.kt
@@ -2,6 +2,7 @@ package smalltalk.backend.config.websocket
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.MessageChannel
 import org.springframework.messaging.converter.MappingJackson2MessageConverter
 import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
@@ -60,4 +61,3 @@ class WebSocketConfig (
             messageConverter = MappingJackson2MessageConverter()
         }
 }
-

--- a/src/test/kotlin/smalltalk/backend/apply/StompMessagingTest.kt
+++ b/src/test/kotlin/smalltalk/backend/apply/StompMessagingTest.kt
@@ -1,0 +1,39 @@
+package smalltalk.backend.apply
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.mockk
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
+import org.springframework.web.socket.messaging.WebSocketStompClient
+import smalltalk.backend.application.implement.message.MessageBroker
+import smalltalk.backend.presentation.dto.message.Message
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class StompMessagingTest(
+    val client: WebSocketStompClient,
+    @LocalServerPort
+    val port: Int
+) : FunSpec({
+    val logger = KotlinLogging.logger { }
+    val handler = mockk<StompSessionHandlerAdapter>(relaxed = true)
+    val webSocketUrl = "ws://localhost:$port/ws-connect"
+    val destinationToSubscribe = "/rooms/1"
+    val destinationToSend = "/rooms/chat/1"
+
+    test("메시지를 전송한다") {
+        val session = client.connectAsync(webSocketUrl, handler).join()
+        session.subscribe(destinationToSubscribe, handler)
+        session.send(
+            destinationToSend,
+            Message(
+                "관리자",
+                "입장"
+            )
+        )
+        Thread.sleep(500)
+        session.disconnect()
+        client.stop()
+    }
+})

--- a/src/test/kotlin/smalltalk/backend/apply/websocket/StompConnectionTests.kt
+++ b/src/test/kotlin/smalltalk/backend/apply/websocket/StompConnectionTests.kt
@@ -1,4 +1,4 @@
-package smalltalk.backend.apply
+package smalltalk.backend.apply.websocket
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.FunSpec

--- a/src/test/kotlin/smalltalk/backend/apply/websocket/StompMessagingTest.kt
+++ b/src/test/kotlin/smalltalk/backend/apply/websocket/StompMessagingTest.kt
@@ -1,4 +1,4 @@
-package smalltalk.backend.apply
+package smalltalk.backend.apply.websocket
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.FunSpec
@@ -7,7 +7,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter
 import org.springframework.web.socket.messaging.WebSocketStompClient
-import smalltalk.backend.application.implement.message.MessageBroker
 import smalltalk.backend.presentation.dto.message.Message
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)


### PR DESCRIPTION
## 😁 Summary
- 메시지 전송을 위한 테스트 코드를 작성하였습니다.
  1. 클라이언트의 웹소켓 연결
  2. 구독
  3. 메시지 전송
<br></br>
- 클라이언트의 구독 요청에 서버는 Receipt 메시지를 전송합니다.
  - Outbound Channel Interceptor에서 확인
<br></br>

## 📌 Issue
- close #23
<br></br>

## 💁‍♂️ Etc
- 메시지 타입은 `message.headers["simpMessageType"]` 로 확인하시는 게 좋을 것 같습니다.
<br></br>
